### PR TITLE
Add solution detail pages and navigation links

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -8,7 +8,12 @@ export const headerData = {
     },
     {
       text: 'ソリューション',
-      href: getPermalink('/#solutions'),
+      links: [
+        { text: 'ソリューション一覧', href: getPermalink('/#solutions') },
+        { text: '楽Platformの開発販売', href: getPermalink('/solution/rakuplatform') },
+        { text: 'Salesforce導入・運用支援', href: getPermalink('/solution/salesforce') },
+        { text: '各種SaaSシステム受託開発', href: getPermalink('/solution/others') },
+      ],
     },
     {
       text: '会社情報',
@@ -29,6 +34,9 @@ export const footerData = {
       links: [
         { text: 'ホーム', href: getPermalink('/', 'home') },
         { text: 'ソリューション', href: getPermalink('/#solutions') },
+        { text: '楽Platformの開発販売', href: getPermalink('/solution/rakuplatform') },
+        { text: 'Salesforce導入・運用支援', href: getPermalink('/solution/salesforce') },
+        { text: '各種SaaSシステム受託開発', href: getPermalink('/solution/others') },
         { text: '会社情報', href: getPermalink('/#about') },
         { text: 'お問い合わせ', href: getPermalink('/contact') },
       ],

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,18 +53,21 @@ const metadata = {
         description:
           '全ての業務をひとつで管理できる総合SaaSプラットフォーム。知識がなくてもスピーディーに構築でき、コストと時間を最小限に抑えます。',
         icon: 'tabler:layout-dashboard',
+        callToAction: { text: '詳しく見る', href: '/solution/rakuplatform' },
       },
       {
         title: 'Salesforce導入・運用支援',
         description:
           '10年以上、50社以上のプロジェクトを支援してきた知見で、導入計画から全体設計、開発、運用までを伴走します。',
         icon: 'tabler:chart-dots',
+        callToAction: { text: '詳しく見る', href: '/solution/salesforce' },
       },
       {
         title: '各種SaaSシステム受託開発',
         description:
           'Salesforce以外の業務管理システムやAPI連携も柔軟に対応。最適なサービス選定から開発、保守までワンストップで提供します。',
         icon: 'tabler:cloud',
+        callToAction: { text: '詳しく見る', href: '/solution/others' },
       },
     ]}
   />

--- a/src/pages/solution/others.astro
+++ b/src/pages/solution/others.astro
@@ -1,0 +1,159 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import Content from '~/components/widgets/Content.astro';
+import Features from '~/components/widgets/Features.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: '各種SaaSシステム受託開発 | Rakucloud株式会社',
+  description:
+    'Salesforce以外の業務管理システムやAPI連携開発など、各種SaaSシステムの受託開発・運用支援についてご紹介します。',
+};
+---
+
+<Layout metadata={metadata}>
+  <Hero
+    tagline="SOLUTION"
+    title="各種SaaSシステム受託開発"
+    subtitle="Salesforce以外のSaaSや基幹システムでも、要件定義から開発・運用まで一気通貫で支援。ビジネスに最適な構成でスピーディーに提供します。"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'お問い合わせ',
+        href: '/contact',
+      },
+      {
+        variant: 'secondary',
+        text: '開発相談をする',
+        href: '/contact',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=2070&q=80',
+      alt: 'SaaSシステムの開発を進めるチーム',
+    }}
+  />
+
+  <Content
+    tagline="PROBLEM"
+    title="SaaSシステムについて、こんなお悩みありませんか？"
+    items={[
+      {
+        title: '導入方法がわからない',
+        description: '数多くのSaaSからどれを選ぶべきか、どのように業務へ組み込むべきか判断できない。',
+      },
+      {
+        title: '運用の最適化ができない',
+        description: '現状の運用が正しいのか不安で、社内にノウハウがなく改善が進まない。',
+      },
+      {
+        title: '機能開発・連携に時間がかかる',
+        description: '業務に合わせたカスタマイズや外部サービスとのAPI連携に多くの工数が必要。',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&w=2070&q=80',
+      alt: 'SaaS導入を検討するチーム',
+    }}
+  >
+    <Fragment slot="content">
+      <p>
+        Rakucloudは、Salesforce以外にも多彩なSaaSや業務システムの開発・連携実績を持ち、
+        お客様のビジネスに最適なサービス選定から導入後の運用まで一貫してサポートします。
+      </p>
+    </Fragment>
+  </Content>
+
+  <Features
+    tagline="STRENGTH"
+    title="受託開発の強み"
+    subtitle="経験豊富なチームがスピードと品質を両立します。"
+    items={[
+      {
+        title: '幅広い導入実績',
+        description: '10年以上、50件を超えるSaaS導入・開発に携わり、多種多様な業界の課題を解決してきました。',
+      },
+      {
+        title: '複雑な要件にも対応',
+        description: 'オブジェクト設計やAPI連携など、複雑なシステム構成でも柔軟にカスタマイズし最適な提案を行います。',
+      },
+      {
+        title: '専門エンジニアによる伴走',
+        description: '得意分野の異なるエンジニアが連携し、課題に適したチームでスピーディーにプロジェクトを進めます。',
+      },
+    ]}
+  />
+
+  <Content
+    tagline="SERVICE"
+    title="支援領域"
+    items={[
+      {
+        title: 'サービス選定と要件整理',
+        description: '業務フローや既存システムを分析し、目的に適したSaaSの選定と要件整理を実施します。',
+      },
+      {
+        title: '開発・カスタマイズ',
+        description: 'ノーコード/ローコードからスクラッチ開発まで、必要な機能を短期間で構築します。',
+      },
+      {
+        title: '運用・改善サポート',
+        description: '導入後の教育や改善提案、運用代行までワンストップで支援します。',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=2070&q=80',
+      alt: 'プロジェクト支援の打ち合わせ',
+    }}
+  >
+    <Fragment slot="content">
+      <p>
+        既存の業務に合わせたカスタマイズはもちろん、複数システムを跨いだデータ連携やダッシュボード構築まで幅広く対応。
+        長期的な改善を見据えた柔軟な体制でサポートします。
+      </p>
+    </Fragment>
+  </Content>
+
+  <Steps
+    title="支援開始までの3ステップ"
+    subtitle="最短でプロジェクトをスタートできるよう丁寧に伴走します。"
+    items={[
+      {
+        title: 'Step 1: お問い合わせ',
+        description: 'フォームから課題やご希望をお知らせください。担当者がヒアリング日程をご案内します。',
+        icon: 'tabler:message-circle',
+      },
+      {
+        title: 'Step 2: オンラインMTG',
+        description: '利用目的や範囲、連携したいシステムを確認し、概算スケジュールとご提案内容を共有します。',
+        icon: 'tabler:calendar-event',
+      },
+      {
+        title: 'Step 3: 開発・導入',
+        description: '要件に合わせて開発を進め、納品後も運用定着と改善まで継続的にサポートします。',
+        icon: 'tabler:rocket',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=2070&q=80',
+      alt: 'オンラインミーティングを行うメンバー',
+    }}
+  />
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: '開発の相談をする',
+        href: '/contact',
+      },
+    ]}
+  >
+    <Fragment slot="title">SaaS開発・連携のことはRakucloudへ</Fragment>
+    <Fragment slot="subtitle">
+      システム選定から運用改善まで、まずはお気軽にご相談ください。最適なチームでプロジェクトをサポートします。
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/solution/rakuplatform.astro
+++ b/src/pages/solution/rakuplatform.astro
@@ -1,0 +1,162 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import Content from '~/components/widgets/Content.astro';
+import Features from '~/components/widgets/Features.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: '楽Platformの開発販売 | Rakucloud株式会社',
+  description:
+    '全ての業務をひとつに集約できる総合SaaSプラットフォーム「楽Platform」の特徴や導入プロセス、対応領域をご紹介します。',
+};
+---
+
+<Layout metadata={metadata}>
+  <Hero
+    tagline="SOLUTION"
+    title="楽Platformの開発販売"
+    subtitle="全ての業務をひとつで管理し、導入コストと開発工数を最小限に。ノーコードで拡張できる総合SaaSプラットフォームが、貴社のDX化を加速させます。"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'お問い合わせ',
+        href: '/contact',
+      },
+      {
+        variant: 'secondary',
+        text: '資料請求',
+        href: '/contact',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=2070&q=80',
+      alt: '業務管理を可視化するダッシュボード',
+    }}
+  />
+
+  <Content
+    tagline="PROBLEM"
+    title="業務管理システムについて、こんなお悩みありませんか？"
+    items={[
+      {
+        title: '導入・運用の高いコスト',
+        description:
+          'SFAやCRMを導入したいが初期費用・運用費がネックとなり、踏み出せない。',
+      },
+      {
+        title: '膨大な機能開発工数',
+        description:
+          '自社の業務に合わせた機能開発に膨大な時間がかかり、現場に定着しない。',
+      },
+      {
+        title: '複雑な業務管理と分断されたデータ',
+        description:
+          '複数ツールの併用により業務が複雑化し、データが分散して把握しづらい。',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1483478550801-781679dc0c44?auto=format&fit=crop&w=2070&q=80',
+      alt: '課題に直面するビジネスチーム',
+    }}
+  >
+    <Fragment slot="content">
+      <p>
+        楽Platformは、業務管理に関する代表的な課題を解消するために生まれた総合SaaSプラットフォームです。導入・運用コストを抑えつつ、
+        ノーコードで柔軟に拡張できるため、専門知識がなくてもスピーディーに業務にフィットした仕組みを構築できます。
+      </p>
+    </Fragment>
+  </Content>
+
+  <Features
+    tagline="FEATURES"
+    title="楽Platformの3つの特徴"
+    subtitle="導入のしやすさから運用の柔軟性まで、誰もが活用できる仕組みをご提供します。"
+    items={[
+      {
+        title: '導入・運用がしやすいコスト設計',
+        description: '課題を抱える企業が無理なく導入できるよう、初期費用から運用費用まで最小限に抑えたプランをご用意しています。',
+      },
+      {
+        title: '自社で高速に開発・改善',
+        description: 'ノーコードかつ高いカスタマイズ性により、現場のメンバーでも業務アプリを素早く構築・改善できます。',
+      },
+      {
+        title: '複数の業務を一元管理',
+        description: '顧客管理、営業管理、勤怠管理、在庫管理、販売管理、人材管理などを一つのプラットフォームで統合できます。',
+      },
+    ]}
+  />
+
+  <Content
+    tagline="CAPABILITY"
+    title="標準機能と柔軟な拡張性"
+    items={[
+      {
+        title: '部門横断のデータ連携',
+        description: '営業・バックオフィス・経営層が同じデータを共有し、リアルタイムに状況把握と意思決定ができます。',
+      },
+      {
+        title: 'プロセス定着を支援するUI/UX',
+        description: '現場の操作性を重視した画面設計により、属人化を防ぎながら標準化された業務プロセスを実現します。',
+      },
+      {
+        title: 'APIや外部SaaSとも連携可能',
+        description: '既存システムや外部サービスとのAPI連携により、社内外のデータを活用した業務改善を推進します。',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=2070&q=80',
+      alt: 'チームでプラットフォームを活用する様子',
+    }}
+  >
+    <Fragment slot="content">
+      <p>
+        標準機能だけでも幅広い業務領域をカバーしつつ、必要に応じて柔軟に拡張できるのが楽Platformの強みです。
+        スモールスタートから全社展開まで段階的に導入でき、成長に合わせてスケールする体制を整えられます。
+      </p>
+    </Fragment>
+  </Content>
+
+  <Steps
+    title="導入までの3ステップ"
+    subtitle="お問い合わせから納品・伴走まで、スムーズに立ち上げをサポートします。"
+    items={[
+      {
+        title: 'Step 1: お問い合わせ',
+        description: 'フォームから資料請求・ご相談内容をご連絡ください。担当者が現状の課題を丁寧にヒアリングします。',
+        icon: 'tabler:message-circle',
+      },
+      {
+        title: 'Step 2: オンラインMTG',
+        description: '導入目的や利用範囲をオンラインで確認し、最適な構成とスケジュールをご提案します。',
+        icon: 'tabler:calendar-event',
+      },
+      {
+        title: 'Step 3: 開発・導入',
+        description: '要件に合わせて当社で設計・カスタマイズし、納品後も運用定着まで伴走します。',
+        icon: 'tabler:rocket',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1521790361543-f645cf042ec4?auto=format&fit=crop&w=2070&q=80',
+      alt: '導入プロセスを議論するビジネスパートナー',
+    }}
+  />
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'お問い合わせ',
+        href: '/contact',
+      },
+    ]}
+  >
+    <Fragment slot="title">楽Platformで業務をひとつにまとめませんか？</Fragment>
+    <Fragment slot="subtitle">
+      導入のご相談やデモのご希望がありましたら、お気軽にお問い合わせください。貴社の課題に合わせた最適なプランをご提案します。
+    </Fragment>
+  </CallToAction>
+</Layout>

--- a/src/pages/solution/salesforce.astro
+++ b/src/pages/solution/salesforce.astro
@@ -1,0 +1,158 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import Content from '~/components/widgets/Content.astro';
+import Features from '~/components/widgets/Features.astro';
+import Steps from '~/components/widgets/Steps.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Salesforce導入・運用支援 | Rakucloud株式会社',
+  description:
+    '約10年以上、50件以上のプロジェクトで培ったSalesforce導入・開発・運用支援のノウハウをご紹介します。',
+};
+---
+
+<Layout metadata={metadata}>
+  <Hero
+    tagline="SOLUTION"
+    title="Salesforce導入・運用支援"
+    subtitle="導入計画の策定から全体設計、カスタマイズ、運用定着まで。豊富な実績を持つエンジニアがSalesforce活用を伴走支援します。"
+    actions={[
+      {
+        variant: 'primary',
+        text: 'お問い合わせ',
+        href: '/contact',
+      },
+      {
+        variant: 'secondary',
+        text: '支援内容を相談する',
+        href: '/contact',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Salesforce活用の打ち合わせ',
+    }}
+  />
+
+  <Content
+    tagline="PROBLEM"
+    title="Salesforceについて、こんなお悩みありませんか？"
+    items={[
+      {
+        title: '導入方法がわからない',
+        description: 'Salesforceを導入したいが、どの機能から着手すべきか判断できない。',
+      },
+      {
+        title: '最適な運用への不安',
+        description: '現在の使い方が正しいのか、組織に合った運用プロセスになっているのか確信が持てない。',
+      },
+      {
+        title: '開発リソースと時間が不足',
+        description: '機能追加や他システム連携に時間がかかり、CRMの改善が進まない。',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1526374965328-7f61d4dc18c5?auto=format&fit=crop&w=2070&q=80',
+      alt: '課題を共有するビジネスチーム',
+    }}
+  >
+    <Fragment slot="content">
+      <p>
+        Rakucloudは、Salesforce導入から運用改善まで幅広い課題を支援してきたパートナーです。お客様のビジネスモデルに合わせた
+        最適なアーキテクチャとプロセスを設計し、スピーディーな改善サイクルを構築します。
+      </p>
+    </Fragment>
+  </Content>
+
+  <Features
+    tagline="STRENGTH"
+    title="Rakucloudの3つの強み"
+    subtitle="長年の経験と体制でSalesforce活用を成功に導きます。"
+    items={[
+      {
+        title: '豊富な導入実績',
+        description: '約10年以上、50以上の企業を支援。導入計画から全体設計、開発、運用まで一貫して伴走してきました。',
+      },
+      {
+        title: '大規模な開発経験',
+        description: '複雑なオブジェクト設計やAPEX開発、API連携など、要件に応じた高度なカスタマイズに対応します。',
+      },
+      {
+        title: '専門エンジニアによる体制',
+        description: 'Salesforceの知見を持つエンジニアが多数在籍。スピーディーかつ的確に課題解決へ導きます。',
+      },
+    ]}
+  />
+
+  <Content
+    tagline="SUPPORT"
+    title="導入から運用までの支援内容"
+    items={[
+      {
+        title: '導入戦略と要件定義',
+        description: '業務ヒアリングを通じて、スモールスタートから全社展開まで見据えた導入計画と要件を整理します。',
+      },
+      {
+        title: '設計・開発・連携構築',
+        description: '標準機能の活用からカスタム開発、外部SaaSや既存システムとの連携まで最適な構成を実現します。',
+      },
+      {
+        title: '定着支援と継続改善',
+        description: '運用チームの教育やレポート整備、改善提案を通じて活用度を高め、成果創出を後押しします。',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=2070&q=80',
+      alt: 'プロジェクトの連携設計を議論する様子',
+    }}
+  >
+    <Fragment slot="content">
+      <p>
+        プロジェクトのフェーズに応じて柔軟に支援範囲を選択いただけます。既存環境の診断やPoCのサポート、長期的な運用代行などもご相談ください。
+      </p>
+    </Fragment>
+  </Content>
+
+  <Steps
+    title="支援開始までの3ステップ"
+    subtitle="お問い合わせから最短で伴走体制を構築します。"
+    items={[
+      {
+        title: 'Step 1: お問い合わせ',
+        description: 'フォームより現状の課題やご希望をお知らせください。担当よりヒアリング日程をご連絡します。',
+        icon: 'tabler:message-circle',
+      },
+      {
+        title: 'Step 2: オンラインMTG',
+        description: '導入目的やスコープ、体制をオンラインで確認し、概算スケジュールと支援プランをご提案します。',
+        icon: 'tabler:calendar-event',
+      },
+      {
+        title: 'Step 3: プロジェクト開始',
+        description: '合意した内容に基づき、設計・開発・運用支援をスタート。課題に応じて継続的に改善します。',
+        icon: 'tabler:rocket',
+      },
+    ]}
+    image={{
+      src: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=2070&q=80',
+      alt: 'プロジェクト計画を共有するチーム',
+    }}
+  />
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Salesforceの相談をする',
+        href: '/contact',
+      },
+    ]}
+  >
+    <Fragment slot="title">Salesforce活用のパートナーにお任せください</Fragment>
+    <Fragment slot="subtitle">
+      導入・運用に関するお悩みはお気軽にご相談ください。貴社の状況に合わせた体制とスケジュールをご提案いたします。
+    </Fragment>
+  </CallToAction>
+</Layout>


### PR DESCRIPTION
## Summary
- add dedicated solution detail pages covering 楽Platform、Salesforce支援、各種SaaS受託開発
- expose the new pages via header/footer navigation and homepage solution cards

## Testing
- `npm run build` *(fails locally because remote image fetching is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68e0f84537e48325811efe9bc90447b2