### PR TITLE
Remove announcement banner from layout

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,7 +2,6 @@
 import Layout from '~/layouts/Layout.astro';
 import Header from '~/components/widgets/Header.astro';
 import Footer from '~/components/widgets/Footer.astro';
-import Announcement from '~/components/widgets/Announcement.astro';
 
 import { headerData, footerData } from '~/navigation';
 
@@ -16,9 +15,7 @@ const { metadata } = Astro.props;
 ---
 
 <Layout metadata={metadata}>
-  <slot name="announcement">
-    <Announcement />
-  </slot>
+  <slot name="announcement" />
   <slot name="header">
     <Header {...headerData} isSticky showRssFeed showToggleTheme />
   </slot>


### PR DESCRIPTION
## Summary
- remove the default announcement banner content from the shared page layout
- retain the announcement slot so pages can provide custom content if needed

## Testing
- npm run dev -- --host 0.0.0.0 --port 4321


------
https://chatgpt.com/codex/tasks/task_b_68e0fcdfc07083258348d5ab6ec5ad8a