### PR TITLE
Update about page with Rakucloud company profile

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,228 +1,157 @@
 ---
-import Features2 from '~/components/widgets/Features2.astro';
-import Features3 from '~/components/widgets/Features3.astro';
 import Hero from '~/components/widgets/Hero.astro';
-import Stats from '~/components/widgets/Stats.astro';
-import Steps2 from '~/components/widgets/Steps2.astro';
 import Layout from '~/layouts/PageLayout.astro';
 
 const metadata = {
-  title: 'About us',
+  title: '会社情報',
 };
+
+const overview = [
+  { label: '会社名', value: 'Rakucloud株式会社' },
+  { label: '設立', value: '2023年8月' },
+  { label: '資本金', value: '1,000,000円' },
+  { label: '代表取締役社長', value: '張壮壮' },
+  { label: '所在地', value: '〒115-0045 東京都北区赤羽1-55-8 501' },
+];
+
+const businesses = [
+  '総合SaaSプラットフォーム「楽Platform」の開発・販売',
+  'Salesforceの導入・運用支援',
+  '各種SaaSシステムの受託開発',
+];
+
+const certificationGroups = [
+  {
+    title: 'Salesforce保有資格',
+    items: [
+      'Salesforce 認定システムアーキテクト',
+      'Salesforce 認定アプリケーションアーキテクト',
+      'Salesforce 認定上級 Platform デベロッパー',
+      'Salesforce 認定 Sales Cloud コンサルタント',
+      'Salesforce 認定 Service Cloud コンサルタント',
+      'Salesforce 認定 Community Cloud コンサルタント',
+      'Salesforce 認定 Data アーキテクト',
+      'Salesforce 認定 Identity and Access Management アーキテクト',
+      'Salesforce 認定 Sharing and Visibility アーキテクト',
+      'Salesforce 認定 Integration アーキテクト',
+      'Salesforce 認定 Development Lifecycle and Deployment アーキテクト',
+      'Salesforce 認定 Platform デベロッパー',
+      'Salesforce 認定 Platform アプリケーションビルダー',
+      'Salesforce 認定 アドミニストレーター',
+      'Salesforce 認定 JavaScript デベロッパー',
+      'Salesforce 認定 AI アソシエイト',
+    ],
+  },
+  {
+    title: 'Marketing Cloud保有資格',
+    items: [
+      'Marketing Cloud Administrator',
+      'Marketing Cloud Email Specialist',
+      'Marketing Cloud Developer',
+      'Marketing Cloud Consultant',
+    ],
+  },
+  {
+    title: 'Tableau保有資格',
+    items: ['Tableau Desktop Specialist'],
+  },
+  {
+    title: 'Dynamics 365 / Power Platform保有資格',
+    items: [
+      'Microsoft Dynamics 365 Sales Functional Consultant Associate',
+      'Microsoft Power Platform App Maker Associate',
+      'Microsoft Dynamics 365 Marketing Functional Consultant Associate',
+      'Microsoft Azure AI Fundamentals',
+    ],
+  },
+  {
+    title: 'Azure保有資格',
+    items: [
+      'Microsoft Certified: Azure Fundamentals',
+      'Microsoft Certified: Azure AI Fundamentals',
+      'Microsoft Certified: Azure Data Fundamentals',
+    ],
+  },
+];
 ---
 
 <Layout metadata={metadata}>
-  <!-- Hero Widget ******************* -->
-
   <Hero
-    tagline="About us"
+    tagline="会社情報"
     image={{
-      src: 'https://images.unsplash.com/photo-1559136555-9303baea8ebd?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2070&q=80',
-      alt: 'Caos Image',
+      src: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=2070&q=80',
+      alt: 'Rakucloudチームのビジネスミーティング',
     }}
   >
-    <Fragment slot="title">
-      Elevate your online presence with our <br />
-      <span class="text-accent dark:text-white"> Beautiful Website Templates</span>
-    </Fragment>
-
+    <Fragment slot="title">Rakucloud株式会社について</Fragment>
     <Fragment slot="subtitle">
-      Donec efficitur, ipsum quis congue luctus, mauris magna convallis mauris, eu auctor nisi lectus non augue. Donec
-      quis lorem non massa vulputate efficitur ac at turpis. Sed tincidunt ex a nunc convallis, et lobortis nisi tempus.
-      Suspendisse vitae nisi eget tortor luctus maximus sed non lectus.
+      総合SaaSプラットフォーム「楽Platform」の提供をはじめ、Salesforceの導入・運用支援や各種SaaS開発を通じて、お客様のビジネス成長を後押ししています。
     </Fragment>
   </Hero>
 
-  <!-- Stats Widget ****************** -->
+  <section class="py-16 sm:py-20">
+    <div class="mx-auto max-w-5xl px-4 sm:px-6">
+      <h2 class="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">会社概要</h2>
+      <p class="mt-4 text-lg text-muted dark:text-slate-300">
+        Rakucloud株式会社は、クラウド技術を活用したプロダクトとコンサルティングで、企業の業務効率化とデジタル変革を支援しています。
+      </p>
+      <dl class="mt-10 grid gap-6 sm:grid-cols-2">
+        {overview.map((item) => (
+          <div
+            class="rounded-2xl border border-slate-200/70 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-700/60 dark:bg-slate-900/60"
+          >
+            <dt class="text-sm font-semibold uppercase tracking-wide text-secondary dark:text-blue-200">
+              {item.label}
+            </dt>
+            <dd class="mt-2 text-lg font-medium text-slate-900 dark:text-white">
+              {item.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  </section>
 
-  <Stats
-    title="Statistics about us"
-    stats={[
-      { title: 'Offices', amount: '4' },
-      { title: 'Employees', amount: '248' },
-      { title: 'Templates', amount: '12' },
-      { title: 'Awards', amount: '24' },
-    ]}
-  />
+  <section class="py-16 sm:py-20 bg-slate-50 dark:bg-slate-900/40">
+    <div class="mx-auto max-w-5xl px-4 sm:px-6">
+      <h2 class="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">事業内容</h2>
+      <p class="mt-4 text-lg text-muted dark:text-slate-300">
+        クラウド活用に関する豊富な知見をもとに、導入から開発・運用までを一気通貫でサポートします。
+      </p>
+      <ul class="mt-8 space-y-4 text-base text-slate-700 dark:text-slate-300">
+        {businesses.map((item) => (
+          <li class="flex gap-3">
+            <span class="mt-2 h-2 w-2 rounded-full bg-primary dark:bg-primary"></span>
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
 
-  <!-- Features3 Widget ************** -->
-
-  <Features3
-    title="Our templates"
-    subtitle="Etiam scelerisque, enim eget vestibulum luctus, nibh mauris blandit nulla, nec vestibulum risus justo ut enim. Praesent lacinia diam et ante imperdiet euismod."
-    columns={3}
-    isBeforeContent={true}
-    items={[
-      {
-        title: 'Educational',
-        description:
-          'Morbi faucibus luctus quam, sit amet aliquet felis tempor id. Cras augue massa, ornare quis dignissim a, molestie vel nulla.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Interior Design',
-        description:
-          'Vivamus porttitor, tortor convallis aliquam pretium, turpis enim consectetur elit, vitae egestas purus erat ac nunc nulla.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Photography',
-        description:
-          'Duis sed lectus in nisl vehicula porttitor eget quis odio. Aliquam erat volutpat. Nulla eleifend nulla id sem fermentum.',
-        icon: 'tabler:template',
-      },
-    ]}
-  />
-
-  <!-- Features3 Widget ************** -->
-
-  <Features3
-    columns={3}
-    isAfterContent={true}
-    items={[
-      {
-        title: 'E-commerce',
-        description:
-          'Rutrum non odio at vehicula. Proin ipsum justo, dignissim in vehicula sit amet, dignissim id quam. Sed ac tincidunt sapien.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Blog',
-        description:
-          'Nullam efficitur volutpat sem sed fringilla. Suspendisse et enim eu orci volutpat laoreet ac vitae libero.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Business',
-        description:
-          'Morbi et elit finibus, facilisis justo ut, pharetra ipsum. Donec efficitur, ipsum quis congue luctus, mauris magna.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Branding',
-        description:
-          'Suspendisse vitae nisi eget tortor luctus maximus sed non lectus. Cras malesuada pretium placerat. Nullam venenatis dolor a ante rhoncus.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Medical',
-        description:
-          'Vestibulum malesuada lacus id nibh posuere feugiat. Nam volutpat nulla a felis ultrices, id suscipit mauris congue. In hac habitasse platea dictumst.',
-        icon: 'tabler:template',
-      },
-      {
-        title: 'Fashion Design',
-        description:
-          'Maecenas eu tellus eget est scelerisque lacinia et a diam. Aliquam velit lorem, vehicula id fermentum et, rhoncus et purus.',
-        icon: 'tabler:template',
-      },
-    ]}
-    image={{
-      src: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1740&q=80',
-      alt: 'Colorful Image',
-    }}
-  />
-
-  <!-- Steps2 Widget ****************** -->
-
-  <Steps2
-    title="Our values"
-    subtitle="Maecenas eu tellus eget est scelerisque lacinia et a diam. Aliquam velit lorem, vehicula id fermentum et, rhoncus et purus. Nulla facilisi. Vestibulum malesuada lacus."
-    items={[
-      {
-        title: 'Customer-centric approach',
-        description:
-          'Donec id nibh neque. Quisque et fermentum tortor. Fusce vitae dolor a mauris dignissim commodo. Ut eleifend luctus condimentum.',
-      },
-      {
-        title: 'Constant Improvement',
-        description:
-          'Phasellus laoreet fermentum venenatis. Vivamus dapibus pulvinar arcu eget mattis. Fusce eget mauris leo.',
-      },
-      {
-        title: 'Ethical Practices',
-        description:
-          'Vestibulum imperdiet libero et lectus molestie, et maximus augue porta. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.',
-      },
-    ]}
-  />
-
-  <!-- Steps2 Widget ****************** -->
-
-  <Steps2
-    title="Achievements"
-    subtitle="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla, sed porttitor est nibh at nulla."
-    isReversed={true}
-    callToAction={{
-      text: 'See more',
-      href: '/',
-    }}
-    items={[
-      {
-        title: 'Global reach',
-        description: 'Nam malesuada urna in enim imperdiet tincidunt. Phasellus non tincidunt nisi, at elementum mi.',
-        icon: 'tabler:globe',
-      },
-      {
-        title: 'Positive customer feedback and reviews',
-        description:
-          'Cras semper nulla leo, eget laoreet erat cursus sed. Praesent faucibus massa in purus iaculis dictum.',
-        icon: 'tabler:message-star',
-      },
-      {
-        title: 'Awards and recognition as industry experts',
-        description:
-          'Phasellus lacinia cursus velit, eu malesuada magna pretium eu. Etiam aliquet tellus purus, blandit lobortis ex rhoncus vitae.',
-        icon: 'tabler:award',
-      },
-    ]}
-  />
-
-  <!-- Features2 Widget ************** -->
-
-  <Features2
-    title="Our locations"
-    tagline="Find us"
-    columns={4}
-    items={[
-      {
-        title: 'EE.UU',
-        description: '1234 Lorem Ipsum St, 12345, Miami',
-      },
-      {
-        title: 'Spain',
-        description: '5678 Lorem Ipsum St, 56789, Madrid',
-      },
-      {
-        title: 'Australia',
-        description: '9012 Lorem Ipsum St, 90123, Sydney',
-      },
-      {
-        title: 'Brazil',
-        description: '3456 Lorem Ipsum St, 34567, São Paulo',
-      },
-    ]}
-  />
-
-  <!-- Features2 Widget ************** -->
-
-  <Features2
-    title="Technical Support"
-    tagline="Contact us"
-    columns={2}
-    items={[
-      {
-        title: 'Chat with us',
-        description:
-          'Integer luctus laoreet libero, auctor varius purus rutrum sit amet. Ut nec molestie nisi, quis eleifend mi.',
-        icon: 'tabler:messages',
-      },
-      {
-        title: 'Call us',
-        description:
-          'Mauris faucibus finibus orci, in posuere elit viverra non. In hac habitasse platea dictumst. Cras lobortis metus a hendrerit congue.',
-        icon: 'tabler:headset',
-      },
-    ]}
-  />
+  <section class="py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6">
+      <h2 class="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">保有資格</h2>
+      <p class="mt-4 text-lg text-muted dark:text-slate-300">
+        Salesforceを中心に、マーケティング、BI、マイクロソフト技術領域まで幅広い資格を保有し、高度な専門性でプロジェクトを支援しています。
+      </p>
+      <div class="mt-10 grid gap-8 md:grid-cols-2">
+        {certificationGroups.map((group) => (
+          <div
+            class="rounded-2xl border border-slate-200/70 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-700/60 dark:bg-slate-900/60"
+          >
+            <h3 class="text-xl font-semibold text-slate-900 dark:text-white">{group.title}</h3>
+            <ul class="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+              {group.items.map((item) => (
+                <li class="flex gap-3">
+                  <span class="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-accent"></span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
 </Layout>


### PR DESCRIPTION
## Summary
- replace the generic about page with Japanese-language content that matches Rakucloud株式会社の会社情報
- add structured sections for company overview, business domains, and certification groups based on the official site

## Testing
- npm run check:astro

------
https://chatgpt.com/codex/tasks/task_b_68e0ff7d0acc8325b380a59fafec4515