### PR TITLE
Add XML endpoints for RSS and sitemap

### DIFF
--- a/src/components/common/CommonMeta.astro
+++ b/src/components/common/CommonMeta.astro
@@ -5,4 +5,4 @@ import { getAsset } from '~/utils/permalinks';
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-<link rel="sitemap" href={getAsset('/sitemap-index.xml')} />
+<link rel="sitemap" href={getAsset('/sitemap.xml')} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,21 +1,14 @@
 import { getRssString } from '@astrojs/rss';
 
-import { SITE, METADATA, APP_BLOG } from 'astrowind:config';
+import { SITE, METADATA } from 'astrowind:config';
 import { fetchPosts } from '~/utils/blog';
 import { getPermalink } from '~/utils/permalinks';
 
 export const GET = async () => {
-  if (!APP_BLOG.isEnabled) {
-    return new Response(null, {
-      status: 404,
-      statusText: 'Not found',
-    });
-  }
-
   const posts = await fetchPosts();
 
   const rss = await getRssString({
-    title: `${SITE.name}’s Blog`,
+    title: `${SITE.name} RSS Feed`,
     description: METADATA?.description || '',
     site: import.meta.env.SITE,
 

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,56 @@
+import { SITE } from 'astrowind:config';
+
+import { getCanonical, getPermalink } from '~/utils/permalinks';
+
+const STATIC_ROUTES = [
+  '/',
+  '/about',
+  '/contact',
+  '/privacy',
+  '/terms',
+  '/solution/rakuplatform',
+  '/solution/salesforce',
+  '/solution/others',
+];
+
+const toAbsoluteUrl = (path: string): string => {
+  const permalink = path === '/' ? getPermalink('/', 'home') : getPermalink(path);
+  const canonical = getCanonical(permalink);
+  return typeof canonical === 'string' ? canonical : canonical.toString();
+};
+
+const generateSitemap = (urls: string[]): string => {
+  const lastmod = new Date().toISOString();
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    urls
+      .map(
+        (url) =>
+          `  <url>\n` +
+          `    <loc>${url}</loc>\n` +
+          `    <lastmod>${lastmod}</lastmod>\n` +
+          `  </url>`
+      )
+      .join('\n') +
+    `\n</urlset>`;
+};
+
+export const GET = async () => {
+  if (!SITE?.site) {
+    return new Response(null, {
+      status: 500,
+      statusText: 'SITE.site is not defined in configuration.',
+    });
+  }
+
+  const urls = Array.from(new Set(STATIC_ROUTES.map(toAbsoluteUrl))).sort();
+
+  const sitemap = generateSitemap(urls);
+
+  return new Response(sitemap, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+};

--- a/vendor/integration/index.ts
+++ b/vendor/integration/index.ts
@@ -74,22 +74,24 @@ export default ({ config: _themeConfig = 'src/config.yaml' } = {}): AstroIntegra
 
       'astro:build:done': async ({ logger }) => {
         const buildLogger = logger.fork('astrowind');
-        buildLogger.info('Updating `robots.txt` with `sitemap-index.xml` ...');
+        buildLogger.info('Updating `robots.txt` with sitemap reference ...');
 
         try {
           const outDir = cfg.outDir;
           const publicDir = cfg.publicDir;
-          const sitemapName = 'sitemap-index.xml';
-          const sitemapFile = new URL(sitemapName, outDir);
+          const sitemapCandidates = ['sitemap.xml', 'sitemap-index.xml'];
+          const sitemapName = sitemapCandidates.find((name) => fs.existsSync(new URL(name, outDir)));
+          if (!sitemapName) {
+            return;
+          }
+
           const robotsTxtFile = new URL('robots.txt', publicDir);
           const robotsTxtFileInOut = new URL('robots.txt', outDir);
 
           const hasIntegration =
             Array.isArray(cfg?.integrations) &&
             cfg.integrations?.find((e) => e?.name === '@astrojs/sitemap') !== undefined;
-          const sitemapExists = fs.existsSync(sitemapFile);
-
-          if (hasIntegration && sitemapExists) {
+          if (hasIntegration) {
             const robotsTxt = fs.readFileSync(robotsTxtFile, { encoding: 'utf8', flag: 'a+' });
             const sitemapUrl = new URL(sitemapName, String(new URL(cfg.base, cfg.site)));
             const pattern = /^Sitemap:(.*)$/m;


### PR DESCRIPTION
## Summary
- ensure the RSS feed endpoint always responds even when no blog posts are published
- add a custom sitemap.xml endpoint for key marketing pages and link to it from metadata
- update the integration hook to reference whichever sitemap file is generated when updating robots.txt

## Testing
- npm run build *(fails: external image fetch during build in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e10ac767648325bce2a57fe9d182cf