### PR TITLE
Translate blog interface to Japanese

### DIFF
--- a/src/components/blog/Pagination.astro
+++ b/src/components/blog/Pagination.astro
@@ -10,7 +10,12 @@ export interface Props {
   nextText?: string;
 }
 
-const { prevUrl, nextUrl, prevText = 'Newer posts', nextText = 'Older posts' } = Astro.props;
+const {
+  prevUrl,
+  nextUrl,
+  prevText = '新しい記事へ',
+  nextText = '過去の記事へ',
+} = Astro.props;
 ---
 
 {

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -22,8 +22,8 @@ const relatedPosts = post.tags ? await getRelatedPosts(post, 4) : [];
         container:
           'pt-0 lg:pt-0 md:pt-0 intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade',
       }}
-      title="Related Posts"
-      linkText="View All Posts"
+      title="関連記事"
+      linkText="すべての記事を見る"
       linkUrl={getBlogPermalink()}
       postIds={relatedPosts.map((post) => post.id)}
     />

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -49,13 +49,7 @@ const { post, url } = Astro.props;
               </>
             )
           }
-          {
-            post.readingTime && (
-              <>
-                &nbsp;· <span>{post.readingTime}</span> min read
-              </>
-            )
-          }
+          {post.readingTime && <>&nbsp;· <span>{post.readingTime}</span>分で読めます</>}
         </p>
       </div>
 

--- a/src/components/blog/ToBlogLink.astro
+++ b/src/components/blog/ToBlogLink.astro
@@ -15,6 +15,6 @@ const { textDirection } = I18N;
       ) : (
         <Icon name="tabler:chevron-left" class="w-5 h-5 mr-1 -ml-1.5 rtl:-mr-1.5 rtl:ml-1" />
       )
-    } Back to Blog
+    } ブログ一覧へ戻る
   </Button>
 </div>

--- a/src/components/common/SocialShare.astro
+++ b/src/components/common/SocialShare.astro
@@ -11,10 +11,10 @@ const { text, url, class: className = 'inline-block' } = Astro.props;
 ---
 
 <div class={className}>
-  <span class="align-super font-bold text-slate-500 dark:text-slate-400">Share:</span>
+  <span class="align-super font-bold text-slate-500 dark:text-slate-400">シェア：</span>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Twitter Share"
+    title="Xでシェア"
     data-aw-social-share="twitter"
     data-aw-url={url}
     data-aw-text={text}
@@ -23,7 +23,7 @@ const { text, url, class: className = 'inline-block' } = Astro.props;
       class="w-6 h-6 text-gray-400 dark:text-slate-500 hover:text-black dark:hover:text-slate-300"
     />
   </button>
-  <button class="ml-2 rtl:ml-0 rtl:mr-2" title="Facebook Share" data-aw-social-share="facebook" data-aw-url={url}
+  <button class="ml-2 rtl:ml-0 rtl:mr-2" title="Facebookでシェア" data-aw-social-share="facebook" data-aw-url={url}
     ><Icon
       name="tabler:brand-facebook"
       class="w-6 h-6 text-gray-400 dark:text-slate-500 hover:text-black dark:hover:text-slate-300"
@@ -31,7 +31,7 @@ const { text, url, class: className = 'inline-block' } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Linkedin Share"
+    title="LinkedInでシェア"
     data-aw-social-share="linkedin"
     data-aw-url={url}
     data-aw-text={text}
@@ -42,7 +42,7 @@ const { text, url, class: className = 'inline-block' } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Whatsapp Share"
+    title="WhatsAppでシェア"
     data-aw-social-share="whatsapp"
     data-aw-url={url}
     data-aw-text={text}
@@ -53,7 +53,7 @@ const { text, url, class: className = 'inline-block' } = Astro.props;
   </button>
   <button
     class="ml-2 rtl:ml-0 rtl:mr-2"
-    title="Email Share"
+    title="メールで共有"
     data-aw-social-share="mail"
     data-aw-url={url}
     data-aw-text={text}

--- a/src/components/widgets/BlogHighlightedPosts.astro
+++ b/src/components/widgets/BlogHighlightedPosts.astro
@@ -18,7 +18,7 @@ export interface Props extends Widget {
 
 const {
   title = await Astro.slots.render('title'),
-  linkText = 'View all posts',
+  linkText = 'すべての記事を見る',
   linkUrl = getBlogPermalink(),
   information = await Astro.slots.render('information'),
   postIds = [],

--- a/src/components/widgets/BlogLatestPosts.astro
+++ b/src/components/widgets/BlogLatestPosts.astro
@@ -19,7 +19,7 @@ export interface Props extends Widget {
 
 const {
   title = await Astro.slots.render('title'),
-  linkText = 'View all posts',
+  linkText = 'すべての記事を見る',
   linkUrl = getBlogPermalink(),
   information = await Astro.slots.render('information'),
   count = 4,

--- a/src/pages/[...blog]/[...page].astro
+++ b/src/pages/[...blog]/[...page].astro
@@ -24,7 +24,7 @@ const currentPage = page.currentPage ?? 1;
 // const allTags = await findTags();
 
 const metadata = {
-  title: `Blog${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
+  title: `ブログ${currentPage > 1 ? ` — ページ ${currentPage}` : ''}`,
   robots: {
     index: blogListRobots?.index && currentPage === 1,
     follow: blogListRobots?.follow,
@@ -37,10 +37,8 @@ const metadata = {
 
 <Layout metadata={metadata}>
   <section class="px-6 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
-    <Headline
-      subtitle="A statically generated blog example with news, tutorials, resources and other interesting content related to AstroWind"
-    >
-      The Blog
+    <Headline subtitle="AstroWindに関するニュース、チュートリアル、リソースなどの最新情報をご紹介します。">
+      ブログ
     </Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />

--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -20,7 +20,7 @@ const { page, category } = Astro.props as Props;
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Category '${category.title}' ${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
+  title: `カテゴリー「${category.title}」${currentPage > 1 ? ` — ページ ${currentPage}` : ''}`,
   robots: {
     index: blogCategoryRobots?.index,
     follow: blogCategoryRobots?.follow,

--- a/src/pages/[...blog]/[tag]/[...page].astro
+++ b/src/pages/[...blog]/[tag]/[...page].astro
@@ -20,7 +20,7 @@ const { page, tag } = Astro.props as Props;
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Posts by tag '${tag.title}'${currentPage > 1 ? ` — Page ${currentPage} ` : ''}`,
+  title: `タグ「${tag.title}」の記事${currentPage > 1 ? ` — ページ ${currentPage}` : ''}`,
   robots: {
     index: blogTagRobots?.index,
     follow: blogTagRobots?.follow,
@@ -30,7 +30,7 @@ const metadata = {
 
 <Layout metadata={metadata}>
   <section class="px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl">
-    <Headline>Tag: {tag.title}</Headline>
+    <Headline>タグ: {tag.title}</Headline>
     <BlogList posts={page.data} />
     <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
   </section>


### PR DESCRIPTION
## Summary
- Localize blog listing and detail pages with Japanese headings, metadata titles, and navigation copy
- Update blog widgets, pagination controls, and social sharing labels to use Japanese defaults

## Testing
- npm run check:eslint

------
https://chatgpt.com/codex/tasks/task_b_68e34156dcec8325b1a9466a104a63c8